### PR TITLE
[KCM/3873] - Rename Helm Chart from cost-analyzer to kubecost

### DIFF
--- a/azure/README.md
+++ b/azure/README.md
@@ -41,13 +41,13 @@ It is recommended to deploy Kubecost Enterprise in this order. Configuring the A
    - **Reach out to your account rep to obtain a license key. This will need to be added to the `kubecostProductConfigs.productKey.key` field in the `values-azure-primary.yaml` file.**
    
 
-   - [ ] Run helm install against the helm chart using the override [values-azure-primary.yaml](/azure/values-azure-primary.yaml) file with the following custom values configured. 
+   - [ ] Run helm install against the helm chart using the override [values-azure-primary.yaml](/azure/values-azure-primary.yaml) file with the following custom values configured.
 ```bash
-      @param global.clusterId=CLUSTER_NAME 
+      @param global.clusterId=CLUSTER_NAME
       @param global.federatedStorage.fileName=federated-store.yaml
       @param cloudCost.enabled=true
       @param cloudCost.cloudIntegration.secret=cloud-integration (only runs on primary)
-      @param kubecostProductConfigs.productKey.enabled=true 
+      @param kubecostProductConfigs.productKey.enabled=true
       @param kubecostProductConfigs.productKey.key=YOUR_PRODUCT_KEY (only runs on primary)
 
       Other options for the productKey are configuring a secret or mounting the key:

--- a/gcp/README.md
+++ b/gcp/README.md
@@ -50,9 +50,9 @@ helm upgrade --install kubecost   --repo https://kubecost.github.io/kubecost/ ku
 
 ## Optional Configuration
 
-4. **Network Costs Daemonset Configured** 
+4. **Network Costs Daemonset Configured**
 
-Please Note: The network cost daemonset will experience CPU throttling and higher memory consumption in large environments where there are several hundred thousand or more unique containers running per day. 
+Please Note: The network cost daemonset will experience CPU throttling and higher memory consumption in large environments where there are several hundred thousand or more unique containers running per day.
 
    - [ ] Review [Configuration Guide](https://www.ibm.com/docs/en/kubecost/self-hosted/3.x?topic=configuration-network-cost)
    - [ ] Apply [Network Cost Config](/azure/network-costs-enabled.yaml)


### PR DESCRIPTION
Updated the documentation to correspond with the Helm chart rename: https://github.com/kubecost/cost-analyzer-helm-chart/pull/4101