### PR TITLE
Add service principal to Azure cloud integration

### DIFF
--- a/azure/cloud-integration.json
+++ b/azure/cloud-integration.json
@@ -8,31 +8,52 @@
         "path": "",
         "cloud": "public/gov",
         "authorizer": {
-          "authorizerType": "AzureDefaultCredential",
+          "authorizerType": "AzureDefaultCredential"
         }
       }
     ]
   }
 }
-/*Use the following config is using a SAS token
+
+# Use the following config is using a SAS token
 {
-    "azure": {
-      "storage": [
-        {
-          "subscriptionID": "",
-          "account": "",
-          "container": "",
-          "path": "",
-          "cloud": "public",
-          "authorizer": {
-            "authorizerType": "AzureStorageConnectionString",
-            "storageConnectionString": "SAS-TOKEN",
-            "httpConfig": {
-              "insecureSkipVerify": true
-            }
+  "azure": {
+    "storage": [
+      {
+        "subscriptionID": "",
+        "account": "",
+        "container": "",
+        "path": "",
+        "cloud": "public",
+        "authorizer": {
+          "authorizerType": "AzureStorageConnectionString",
+          "storageConnectionString": "SAS-TOKEN",
+          "httpConfig": {
+            "insecureSkipVerify": true
           }
         }
-      ]
-    }
+      }
+    ]
   }
-*/
+}
+
+# Use the following for a Service Principal with Client Secret
+{
+  "azure": {
+    "storage": [
+      {
+        "subscriptionID": "",
+        "account": "",
+        "container": "",
+        "path": "",
+        "cloud": "public",
+        "authorizer": {
+          "authorizerType": "AzureClientSecretCredential",
+          "tenantID": "",
+          "clientID": "",
+          "clientSecret": ""
+        }
+      }
+    ]
+  }
+}

--- a/on-prem/values-csv-custom-pricing-primary.yaml
+++ b/on-prem/values-csv-custom-pricing-primary.yaml
@@ -29,7 +29,7 @@ pricingCsv:
     # provider: "AWS"
     # region: "us-east-1"
     # URI: s3://kc-csv-test/pricing_schema.csv # a valid file URI
-    # csvAccessCredentials: pricing-schema-access-secret
+    csvAccessCredentials: "" # leave value set to empty string when not using a CSV pricing access secret
 
 # when using configmap: kubectl create configmap -n kubecost csv-pricing --from-file custom-pricing.csv
 extraVolumes:


### PR DESCRIPTION
Adding the template to the Azure cloud integration to use Service Principal with a client secret, which has been tested with a customer.