### PR TITLE
fix(gcp): secondary cluster install references wrong values file

### DIFF
--- a/azure/README.md
+++ b/azure/README.md
@@ -41,13 +41,13 @@ It is recommended to deploy Kubecost Enterprise in this order. Configuring the A
    - **Reach out to your account rep to obtain a license key. This will need to be added to the `kubecostProductConfigs.productKey.key` field in the `values-azure-primary.yaml` file.**
    
 
-   - [ ] Run helm install against the helm chart using the override [values-azure-primary.yaml](/azure/values-azure-primary.yaml) file with the following custom values configured. 
+   - [ ] Run helm install against the helm chart using the override [values-azure-primary.yaml](/azure/values-azure-primary.yaml) file with the following custom values configured.
 ```bash
-      @param global.clusterId=CLUSTER_NAME 
+      @param global.clusterId=CLUSTER_NAME
       @param global.federatedStorage.fileName=federated-store.yaml
       @param cloudCost.enabled=true
       @param cloudCost.cloudIntegration.secret=cloud-integration (only runs on primary)
-      @param kubecostProductConfigs.productKey.enabled=true 
+      @param kubecostProductConfigs.productKey.enabled=true
       @param kubecostProductConfigs.productKey.key=YOUR_PRODUCT_KEY (only runs on primary)
 
       Other options for the productKey are configuring a secret or mounting the key:

--- a/gcp/README.md
+++ b/gcp/README.md
@@ -42,8 +42,10 @@ helm upgrade --install kubecost   --repo https://kubecost.github.io/kubecost/ ku
    - [ ] Install Kubecost on secondary clusters using [secondary values fle template](/gcp/values-gcp-secondary.yaml).
 
 ```bash
-helm upgrade --install kubecost   --repo https://kubecost.github.io/kubecost/ kubecost   --namespace kedd-primary --create-namespace \
--f values-gcp-primary.yaml
+helm upgrade --install kubecost \
+  --repo https://kubecost.github.io/kubecost/ kubecost \
+  --namespace kubecost \
+  -f values-gcp-secondary.yaml
 ```
   - [ ] Verify ETL pipeline is working by checking that a /federated directory was created in the object-store. If no /federated directory exists, double check configuration, finops-agent pod logs or test that the user can curl the bucket endpoint from inside the finops-agent container.
 

--- a/gcp/README.md
+++ b/gcp/README.md
@@ -21,7 +21,7 @@ This guide provides step-by-step instructions for deploying Kubecost in GCP.
    - [ ] Configure [federated-store.yaml](/gcp/federated-store.yaml) pointing to the google storage bucket configured in step 2 of prerequisites. 
    - [ ] Create secret for object storage in Kubecost namespace.
 ```bash
-   kubectl create secret generic federated-store --from-file=object-store.yaml -n kubecost
+   kubectl create secret generic federated-store --from-file=federated-store.yaml -n kubecost
 ```
 
 2. **Primary Cluster Installation**

--- a/gcp/README.md
+++ b/gcp/README.md
@@ -21,7 +21,7 @@ This guide provides step-by-step instructions for deploying Kubecost in GCP.
    - [ ] Configure [federated-store.yaml](/gcp/federated-store.yaml) pointing to the google storage bucket configured in step 2 of prerequisites. 
    - [ ] Create secret for object storage in Kubecost namespace.
 ```bash
-   kubectl create secret generic federated-store --from-file=federated-store.yaml -n kubecost
+   kubectl create secret generic federated-store --from-file=object-store.yaml -n kubecost
 ```
 
 2. **Primary Cluster Installation**

--- a/gcp/README.md
+++ b/gcp/README.md
@@ -50,9 +50,9 @@ helm upgrade --install kubecost   --repo https://kubecost.github.io/kubecost/ ku
 
 ## Optional Configuration
 
-4. **Network Costs Daemonset Configured** 
+4. **Network Costs Daemonset Configured**
 
-Please Note: The network cost daemonset will experience CPU throttling and higher memory consumption in large environments where there are several hundred thousand or more unique containers running per day. 
+Please Note: The network cost daemonset will experience CPU throttling and higher memory consumption in large environments where there are several hundred thousand or more unique containers running per day.
 
    - [ ] Review [Configuration Guide](https://www.ibm.com/docs/en/kubecost/self-hosted/3.x?topic=configuration-network-cost)
    - [ ] Apply [Network Cost Config](/azure/network-costs-enabled.yaml)


### PR DESCRIPTION
## Summary

Step 3 "Secondary Clusters Installation" in `gcp/README.md` was running the helm install with `-f values-gcp-primary.yaml`, which would deploy a second primary instead of an agent.

## Change

Replaced the helm command in step 3 with the correct secondary values file and namespace:

```bash
helm upgrade --install kubecost \
  --repo https://kubecost.github.io/kubecost/ kubecost \
  --namespace kubecost \
  -f values-gcp-secondary.yaml
```

## Acceptance Criteria
- [x] Step 3 helm command references `values-gcp-secondary.yaml`
- [x] Step 2 (primary) still references `values-gcp-primary.yaml`
- [x] No other helm commands in the file were changed